### PR TITLE
Docs: restore and document the live MCP smoke test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,28 @@ uv run okto-nexus
 The final command starts the stdio MCP server. This path is appropriate when a
 change does not need the bundled dashboard or real local semantic search.
 
+### Live MCP smoke test
+
+Run the live client after changing the MCP transport, coordination tools, or
+SQLite persistence, and before opening a pull request that affects those paths:
+
+```bash
+.venv/bin/python scripts/live_client.py
+```
+
+On Windows PowerShell, use the virtual environment's Windows interpreter:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\live_client.py
+```
+
+Unlike the unit suite, this script starts the real stdio MCP server and drives
+an end-to-end two-agent flow through registration, sessions, messaging, event
+delivery, handoff, artifact storage, and `shared.md` rendering. It uses temporary
+home and project directories, then removes them on exit, so it does not touch
+the user's `~/.okto_nexus` data. A successful run ends with
+`LIVE E2E RESULT: PASS`.
+
 ## Full HTTP and dashboard development
 
 Install the full `serve` extra when testing the HTTP transport, dashboard,

--- a/scripts/live_client.py
+++ b/scripts/live_client.py
@@ -179,12 +179,10 @@ async def run() -> int:
                 a1 = await call(
                     session, "agent_register",
                     agent_id="agent-alpha", role="architect",
-                    capabilities=["py", "review"],
                 )
                 a2 = await call(
                     session, "agent_register",
                     agent_id="agent-beta", role="builder",
-                    capabilities=["py"],
                 )
                 envelopes += [a1, a2]
                 require_ok(a1, "agent_register/alpha")


### PR DESCRIPTION
## Summary

- document when and how to run `scripts/live_client.py` on Unix and Windows
- explain the real stdio flow, temporary-state isolation, and PASS signal
- stop the smoke client from declaring unregistered `py` / `review` capabilities, which became invalid after capability registration went fail-closed

Closes #17.

## Why the script changed

Running the requested command against current `main` exposed a real regression before the documentation was added: both `agent_register` calls failed because the live client referenced capability names that are not in a clean store's catalog. The flow does not depend on those labels, so omitting them preserves the intended two-agent coverage and makes the documented clean-checkout command work again.

## Validation

- `.venv/bin/python scripts/live_client.py` — PASS; 43 tools discovered and the message/event/handoff/artifact/`shared.md` flow completed
- `uv run pytest -q` — 1588 passed, 2 skipped
- `uv lock --check` — passed
- `git diff --check` — passed
- `uvx ruff check .` — repository baseline: 372 errors
- targeted script lint reports the same single pre-existing `TRY004` on this branch and `upstream/main`; this change adds no lint finding

## AI assistance

Implemented and verified with OpenAI Codex assistance; I reviewed the diff and the validation results above are from local runs.