### PR TITLE
Release Okto Nexus 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Okto Nexus are documented in this file.
 
+## 0.1.6 - 2026-09-01
+
+### Fixed
+
+- Rebuilt the MCP v1 FastMCP settings model after import so
+  `pydantic-settings` 2.15+ no longer reports an unresolved `lifespan`
+  forward reference during stdio or HTTP server startup.
+
+### Changed
+
+- Constrained the MCP Python SDK dependency to the compatible v1 line
+  (`mcp>=1.0,<2`), keeping the eventual v2 migration explicit.
+
+### Validation
+
+- Verified the installed `okto-nexus serve` executable with the local MiniLM
+  embedding provider and a live `/healthz` request.
+- Passed the complete test suite with 1,589 tests passing and 2 skipped.
+
 ## 0.1.5 - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ the derived `shared.md` view live outside that database.
 
 | Release fact | Value |
 |---|---|
-| Package | `okto-nexus 0.1.5` |
+| Package | `okto-nexus 0.1.6` |
 | Python | `>=3.11` |
 | MCP surface | 43 tools by default; 46 with memory enabled |
 | MCP resources | 12 versioned reference resources |
@@ -694,7 +694,7 @@ Transient SQLite lock/busy failures use `DB_ERROR` with
 
 ### Resident token footprint
 
-For the 0.1.5 default surface:
+For the 0.1.6 default surface:
 
 | Component | Characters |
 |---|---:|
@@ -962,10 +962,10 @@ Release checks:
 
 ```bash
 uv lock --check
-uv build --out-dir dist/release-0.1.5
+uv build --out-dir dist/release-0.1.6
 uvx twine check \
-  dist/release-0.1.5/okto_nexus-0.1.5-py3-none-any.whl \
-  dist/release-0.1.5/okto_nexus-0.1.5.tar.gz
+  dist/release-0.1.6/okto_nexus-0.1.6-py3-none-any.whl \
+  dist/release-0.1.6/okto_nexus-0.1.6.tar.gz
 ```
 
 Publish only explicitly named current-version artifacts. The top-level
@@ -1101,7 +1101,25 @@ and the dashboard.
 
 ## Release notes
 
-### 0.1.5 — current
+### 0.1.6 — current
+
+Startup compatibility maintenance release. The MCP contract and database
+schema are unchanged: surface revision remains 32 and the latest migration
+remains 026.
+
+- Rebuilt the MCP v1 FastMCP settings model after import, eliminating the
+  unresolved `lifespan` forward-reference warning introduced by
+  `pydantic-settings` 2.15.
+- Applied the compatibility path to both stdio and streamable-HTTP server
+  construction.
+- Constrained the MCP SDK dependency to `mcp>=1.0,<2` so adopting the breaking
+  v2 API requires an explicit migration.
+- Added a regression test that promotes the startup warning to an error and
+  verifies the settings model is complete.
+- Verified the installed executable with local MiniLM warm-up, a live health
+  request, and the complete test suite.
+
+### 0.1.5
 
 Live MCP smoke-test maintenance release. The MCP contract and database schema
 are unchanged: surface revision remains 32 and the latest migration remains

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "okto-nexus"
-version = "0.1.5"
+version = "0.1.6"
 description = "Okto Nexus - Local Agent Coordination Bus (MCP server + dashboard)"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -31,7 +31,9 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "mcp>=1.0",
+    # Nexus uses the MCP Python SDK v1 FastMCP API.  Keep v2 as an explicit
+    # migration instead of accepting a breaking major during installation.
+    "mcp>=1.0,<2",
     "pydantic>=2",
 ]
 

--- a/src/okto_nexus/adapters/inbound/http/app.py
+++ b/src/okto_nexus/adapters/inbound/http/app.py
@@ -47,6 +47,7 @@ from ...outbound.tokenizer import resolve_tokenizer
 from ..mcp.server import (
     SERVER_INSTRUCTIONS,
     Deps,
+    _load_fastmcp,
     register_meta_tools,
     register_resources,
     register_tools,
@@ -305,8 +306,7 @@ def create_http_mcp_server(deps: Deps) -> Any:
     at ``okto-nexus://reference/*`` docs (monitoring, preflight, target-grammar,
     tool-docs/*) that must therefore resolve on a ``resources/read``.
     """
-    from mcp.server.fastmcp import FastMCP  # lazy: SDK only needed at serve time
-
+    FastMCP = _load_fastmcp()  # lazy: SDK only needed at serve time
     server = FastMCP(
         "okto-nexus",
         instructions=SERVER_INSTRUCTIONS,

--- a/src/okto_nexus/adapters/inbound/mcp/server.py
+++ b/src/okto_nexus/adapters/inbound/mcp/server.py
@@ -767,13 +767,29 @@ def maybe_auto_prune(deps: Deps) -> dict[str, Any] | None:
     return report
 
 
+def _load_fastmcp() -> Any:
+    """Load the v1 FastMCP class with its settings model fully rebuilt.
+
+    MCP 1.29.0 defines ``Settings`` before ``FastMCP``.  That leaves the
+    generic ``lifespan`` annotation as an unresolved forward reference and
+    pydantic-settings 2.15+ warns every time a server is constructed.  Rebuild
+    after both classes exist, using Pydantic's public hook; fixed SDK releases
+    already report the model complete and take the no-op branch.
+    """
+    from mcp.server.fastmcp import FastMCP
+    from mcp.server.fastmcp.server import Settings
+
+    if not Settings.__pydantic_complete__:
+        Settings.model_rebuild()
+    return FastMCP
+
+
 def create_server(deps: Deps) -> Any:
     """Create the MCP server, register tools, and return the server instance.
 
     Imports the MCP SDK lazily; raises ``ImportError`` if it is missing.
     """
-    from mcp.server.fastmcp import FastMCP  # lazy import: SDK only needed here
-
+    FastMCP = _load_fastmcp()  # lazy import: SDK only needed here
     server = FastMCP("okto-nexus", instructions=SERVER_INSTRUCTIONS)
     register_tools(server, deps)
     register_meta_tools(server, deps)

--- a/tests/test_mcp_settings_compat.py
+++ b/tests/test_mcp_settings_compat.py
@@ -1,0 +1,27 @@
+"""Compatibility guards for the MCP SDK composition boundary."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.server import Settings
+
+from okto_nexus.adapters.inbound.mcp.server import _load_fastmcp
+
+
+def test_fastmcp_settings_lifespan_forward_reference_is_rebuilt() -> None:
+    """Server creation stays warning-free with pydantic-settings 2.15+."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message=r"Field 'lifespan' has an incomplete definition.*",
+        )
+        fastmcp = _load_fastmcp()
+        fastmcp("probe")
+
+    assert Settings.__pydantic_complete__ is True
+    assert Settings.model_fields["lifespan"]._complete is True

--- a/uv.lock
+++ b/uv.lock
@@ -942,7 +942,7 @@ wheels = [
 
 [[package]]
 name = "okto-nexus"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -976,7 +976,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'serve'", specifier = ">=0.110,!=0.137.0" },
     { name = "fastapi", marker = "extra == 'serve-lite'", specifier = ">=0.110,!=0.137.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.5" },


### PR DESCRIPTION
## Summary

- rebuild the MCP v1 FastMCP settings model before server construction to remove the pydantic-settings 2.15 lifespan warning
- constrain the MCP SDK dependency to the compatible v1 line
- bump package metadata, lockfile, README, and changelog to 0.1.6
- add startup compatibility regression coverage

## Validation

- 1,589 tests passed; 2 skipped
- Ruff passed
- uv lock check passed
- wheel and source distribution passed twine check
- installed HTTP startup completed with the local MiniLM provider and healthz returned alive